### PR TITLE
Fix CLI argument in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ runs:
         unset LD_PRELOAD
         unset PYTHONSTARTUP
         python3 -mpip install -r "${{ github.action_path }}/requirements.txt"
-        python3 "${{ github.action_path }}/remap_sarif.py" "${{ inputs.input }}" "${{ inputs.sourceroot }}" --output-sarif "${{ inputs.output }}"
+        python3 "${{ github.action_path }}/remap_sarif.py" "${{ inputs.input }}" "${{ inputs.sourceroot }}" --output "${{ inputs.output }}"
       shell: bash


### PR DESCRIPTION
Hi 👋 . This PR intends to avoid `unrecognized arguments: --output-sarif` error, which I faced during my local evaluation 🙇 .

```
Run advanced-security/remap-sarif@main
Run unset LD_PRELOAD
Defaulting to user installation because normal site-packages is not writeable
Collecting sourcemap==0.2.1
  Downloading sourcemap-0.2.1-py2.py3-none-any.whl (7.4 kB)
Installing collected packages: sourcemap
Successfully installed sourcemap-0.2.1
usage: remap_sarif.py [-h] [--output OUTPUT] [--debug] sarif sourceroot
remap_sarif.py: error: unrecognized arguments: --output-sarif results.sarif
Error: Process completed with exit code 2.
```

The current `action.yml` uses `--output-sarif` argument, but `remap_sarif.py` seems to use `--output` instead.

https://github.com/advanced-security/remap-sarif/blob/b2be2d8171168efb45d4239293a64984002db28e/remap_sarif.py#L18